### PR TITLE
Update html render using iframe

### DIFF
--- a/client/src/__tests__/components/searchResults/HTMLRender.test.js
+++ b/client/src/__tests__/components/searchResults/HTMLRender.test.js
@@ -10,7 +10,6 @@ describe('HTMLRender Component', () => {
     const renderedHTML = screen.getByTestId('rendered-html')
 
     expect(renderedHTML).toBeInTheDocument()
-    expect(renderedHTML).toHaveClass('rounded-md border border-gray-200 p-6')
-    expect(renderedHTML).toHaveProperty('innerHTML', htmlCode)
+    expect(renderedHTML).toHaveClass('rounded-md border border-gray-200')
   })
 })

--- a/client/src/components/searchResults/HTMLRender.tsx
+++ b/client/src/components/searchResults/HTMLRender.tsx
@@ -1,9 +1,11 @@
 export default function HTMLRender({ htmlCode }: { htmlCode: string }) {
   return (
-    <div
+    <iframe
       data-testid="rendered-html"
-      dangerouslySetInnerHTML={{ __html: htmlCode }}
-      className="rounded-md border border-gray-200 p-6"
-    ></div>
+      width="100%"
+      height="3000"
+      srcDoc={htmlCode}
+      className="rounded-md border border-gray-200"
+    />
   )
 }


### PR DESCRIPTION
This pr is created to resolve the broken UI  issue [23](https://github.com/myat-hsu-mon/web-scrapping-app/issues/23).
Now it is using iframe and srcDoc to show the html content from the google search results.